### PR TITLE
Store headers as parsed keys in the json output logs

### DIFF
--- a/addons/megadumper/formatters/plaintext.go
+++ b/addons/megadumper/formatters/plaintext.go
@@ -17,9 +17,8 @@ func (pt *PlainText) flatten() ([]byte, error) {
 
 	buf := new(bytes.Buffer)
 
-	if pt.container.RequestHeaders != "" {
-		buf.WriteString(pt.container.RequestHeaders)
-		buf.WriteString("\r\n")
+	if pt.container.RequestHeaders != nil {
+		buf.WriteString(pt.container.RequestHeadersString())
 	}
 
 	if pt.container.RequestBody != "" {
@@ -27,9 +26,8 @@ func (pt *PlainText) flatten() ([]byte, error) {
 		buf.WriteString("\r\n")
 	}
 
-	if pt.container.ResponseHeaders != "" {
-		buf.WriteString(pt.container.ResponseHeaders)
-		buf.WriteString("\r\n")
+	if pt.container.ResponseHeaders != nil {
+		buf.WriteString(pt.container.ResponseHeadersString())
 	}
 
 	if pt.container.ResponseBody != "" {

--- a/addons/megadumper/formatters/plaintext_test.go
+++ b/addons/megadumper/formatters/plaintext_test.go
@@ -1,25 +1,28 @@
 package formatters
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/robbyt/llm_proxy/schema"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPlainText_flatten(t *testing.T) {
 	container := &schema.LogDumpContainer{
-		RequestHeaders:  "Request Headers",
+		RequestHeaders:  http.Header{"ReqHeader": []string{"ReqValue"}},
 		RequestBody:     "Request Body",
-		ResponseHeaders: "Response Headers",
+		ResponseHeaders: http.Header{"RespHeader": []string{"RespValue"}},
 		ResponseBody:    "Response Body",
 	}
 	pt := &PlainText{container}
 
-	expectedResult := []byte("Request Headers\r\nRequest Body\r\nResponse Headers\r\nResponse Body\r\n")
+	expectedResult := []byte("ReqHeader: ReqValue\r\nRequest Body\r\nRespHeader: RespValue\r\nResponse Body\r\n")
 
 	result, err := pt.flatten()
 	assert.NoError(t, err)
+	spew.Dump(result)
 	assert.Equal(t, expectedResult, result)
 }
 

--- a/schema/logDumpContainer_test.go
+++ b/schema/logDumpContainer_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -18,14 +19,14 @@ func TestNewLogDumpDiskContainer_JSON(t *testing.T) {
 				Host:   "example.com",
 				Path:   "/",
 			},
-			Header: map[string][]string{
-				"Content-Type": {"[application/json]"},
+			Header: http.Header{
+				"Content-Type": []string{"[application/json]"},
 			},
 			Body: []byte(`{"key": "value"}`),
 		},
 		Response: &px.Response{
-			Header: map[string][]string{
-				"Content-Type": {"[application/json]"},
+			Header: http.Header{
+				"Content-Type": []string{"[application/json]"},
 			},
 			Body: []byte(`{"status": "success"}`),
 		},
@@ -33,27 +34,27 @@ func TestNewLogDumpDiskContainer_JSON(t *testing.T) {
 	var container *LogDumpContainer
 
 	container = NewLogDumpContainer(*flow, config.LogSourceConfig{LogRequestHeaders: true}, 0, []string{}, []string{})
-	assert.Equal(t, "Content-Type: [application/json]\r\n", container.RequestHeaders)
+	assert.Equal(t, "Content-Type: [application/json]\r\n", container.RequestHeadersString())
 	assert.Equal(t, "", container.RequestBody)
-	assert.Equal(t, "", container.ResponseHeaders)
+	assert.Equal(t, "", container.ResponseHeadersString())
 	assert.Equal(t, "", container.ResponseBody)
 
 	container = NewLogDumpContainer(*flow, config.LogSourceConfig{LogRequestBody: true}, 0, []string{}, []string{})
-	assert.Equal(t, "", container.RequestHeaders)
+	assert.Equal(t, "", container.RequestHeadersString())
 	assert.Equal(t, `{"key": "value"}`, container.RequestBody)
-	assert.Equal(t, "", container.ResponseHeaders)
+	assert.Equal(t, "", container.ResponseHeadersString())
 	assert.Equal(t, "", container.ResponseBody)
 
 	container = NewLogDumpContainer(*flow, config.LogSourceConfig{LogResponseHeaders: true}, 0, []string{}, []string{})
-	assert.Equal(t, "", container.RequestHeaders)
+	assert.Equal(t, "", container.RequestHeadersString())
 	assert.Equal(t, "", container.RequestBody)
-	assert.Equal(t, "Content-Type: [application/json]\r\n", container.ResponseHeaders)
+	assert.Equal(t, "Content-Type: [application/json]\r\n", container.ResponseHeadersString())
 	assert.Equal(t, "", container.ResponseBody)
 
 	container = NewLogDumpContainer(*flow, config.LogSourceConfig{LogResponseBody: true}, 0, []string{}, []string{})
-	assert.Equal(t, "", container.RequestHeaders)
+	assert.Equal(t, "", container.RequestHeadersString())
 	assert.Equal(t, "", container.RequestBody)
-	assert.Equal(t, "", container.ResponseHeaders)
+	assert.Equal(t, "", container.ResponseHeadersString())
 	assert.Equal(t, `{"status": "success"}`, container.ResponseBody)
 
 	container = NewLogDumpContainer(
@@ -68,9 +69,9 @@ func TestNewLogDumpDiskContainer_JSON(t *testing.T) {
 		[]string{},
 		[]string{},
 	)
-	assert.Equal(t, "Content-Type: [application/json]\r\n", container.RequestHeaders)
+	assert.Equal(t, "Content-Type: [application/json]\r\n", container.RequestHeadersString())
 	assert.Equal(t, `{"key": "value"}`, container.RequestBody)
-	assert.Equal(t, "Content-Type: [application/json]\r\n", container.ResponseHeaders)
+	assert.Equal(t, "Content-Type: [application/json]\r\n", container.ResponseHeadersString())
 	assert.Equal(t, `{"status": "success"}`, container.ResponseBody)
 
 }


### PR DESCRIPTION
Example of the new log output format:
```bash
$ curl \
    http://api.openai.com/v1/chat/completions \
    -x http://localhost:8080 \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer sk-XXXXXXX" \
    -d '{
        "model": "gpt-3.5-turbo",
        "messages": [
            {
                "role": "system",
                "content": "You are a poetic assistant, skilled in explaining complex programming concepts with creative flair."
            },
            {
                "role": "user",
                "content": "Compose a 10 word poem that explains the concept of recursion in programming."
            }
        ]
    }'
```
```JSON
{
  "schema": "v1",
  "timestamp": "2024-02-26T15:28:47.473688-05:00",
  "connection_stats": {
    "client_address": "127.0.0.1:63491",
    "method": "POST",
    "url": "https://api.openai.com/v1/chat/completions",
    "status_code": 200,
    "content_length": 527,
    "duration_ms": 2754,
    "response_content_type": "application/json",
    "proxy_id": "a8d2580d-b5d4-44bc-a670-e5d696297f01"
  },
  "request_headers": {
    "Accept": [
      "*/*"
    ],
    "Content-Length": [
      "432"
    ],
    "Content-Type": [
      "application/json"
    ],
    "Proxy-Connection": [
      "Keep-Alive"
    ],
    "User-Agent": [
      "curl/8.4.0"
    ]
  },
  "request_body": "{\n        \"model\": \"gpt-3.5-turbo\",\n        \"messages\": [\n            {\n                \"role\": \"system\",\n                \"content\": \"You are a poetic assistant, skilled in explaining complex programming concepts with creative flair.\"\n            },\n            {\n                \"role\": \"user\",\n                \"content\": \"Compose a 10 word poem that explains the concept of recursion in programming.\"\n            }\n        ]\n    }",
  "response_headers": {
    "Access-Control-Allow-Origin": [
      "*"
    ],
    "Alt-Svc": [
      "h3=\":443\"; ma=86400"
    ],
    "Cache-Control": [
      "no-cache, must-revalidate"
    ],
    "Cf-Cache-Status": [
      "DYNAMIC"
    ],
    "Cf-Ray": [
      "85baefb7a97d0ca6-EWR"
    ],
    "Connection": [
      "keep-alive"
    ],
    "Content-Length": [
      "527"
    ],
    "Content-Type": [
      "application/json"
    ],
    "Date": [
      "Mon, 26 Feb 2024 20:28:47 GMT"
    ],
    "Openai-Model": [
      "gpt-3.5-turbo-0125"
    ],
    "Openai-Processing-Ms": [
      "604"
    ],
    "Openai-Version": [
      "2020-10-01"
    ],
    "Server": [
      "cloudflare"
    ],
    "Strict-Transport-Security": [
      "max-age=15724800; includeSubDomains"
    ],
    "X-Llm_proxy-Scheme-Upgraded": [
      "true"
    ],
    "X-Ratelimit-Limit-Requests": [
      "10000"
    ],
    "X-Ratelimit-Limit-Tokens": [
      "60000"
    ],
    "X-Ratelimit-Remaining-Requests": [
      "9999"
    ],
    "X-Ratelimit-Remaining-Tokens": [
      "59938"
    ],
    "X-Ratelimit-Reset-Requests": [
      "8.64s"
    ],
    "X-Ratelimit-Reset-Tokens": [
      "62ms"
    ],
    "X-Request-Id": [
      "req_338ff75692dd40889b00894f0fc54d43"
    ]
  },
  "response_body": "{\n  \"id\": \"chatcmpl-8wbsdBsipkCcKkhUp6bDo4P1OOjRh\",\n  \"object\": \"chat.completion\",\n  \"created\": 1708979327,\n  \"model\": \"gpt-3.5-turbo-0125\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": \"Within code's embrace, functions call themselves, a loop infinite.\"\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 42,\n    \"completion_tokens\": 13,\n    \"total_tokens\": 55\n  },\n  \"system_fingerprint\": \"fp_86156a94a0\"\n}\n"
}
```